### PR TITLE
Add Search/Filter Functionality to Installable Models

### DIFF
--- a/src/app.rs
+++ b/src/app.rs
@@ -295,4 +295,15 @@ impl AppState {
             self.registry_filter_cursor_pos += 1;
         }
     }
+
+    /// Returns true if global key handling (like help) should be enabled.
+    /// Global keys are disabled in modes that handle their own input.
+    pub fn is_global_key_handling_enabled(&self) -> bool {
+        !matches!(self.current_mode, 
+            AppMode::RunningOllama 
+            | AppMode::Help 
+            | AppMode::Filter 
+            | AppMode::InstallSelectModelFilter
+        )
+    }
 }

--- a/src/handlers.rs
+++ b/src/handlers.rs
@@ -11,6 +11,23 @@ use tokio::sync::mpsc;
 
 type EventSender = mpsc::Sender<AppEvent>;
 
+/// Handles Ctrl+C clear functionality for filter modes
+fn handle_filter_clear(app: &mut AppState) {
+    match app.current_mode {
+        AppMode::Filter => {
+            app.filter_input.clear();
+            app.filter_cursor_pos = 0;
+            app.apply_filter();
+        }
+        AppMode::InstallSelectModelFilter => {
+            app.registry_filter_input.clear();
+            app.registry_filter_cursor_pos = 0;
+            app.apply_registry_filter();
+        }
+        _ => {} // Should not happen, but handle gracefully
+    }
+}
+
 /// Handles terminal key events.
 /// Returns `Ok(true)` if the application should quit, `Ok(false)` otherwise.
 pub async fn handle_key_event(
@@ -89,9 +106,7 @@ pub async fn handle_key_event(
                 AppMode::Filter => match key.code {
                     KeyCode::Char('c') if key.modifiers.contains(KeyModifiers::CONTROL) => {
                         // Clear filter input with Ctrl+C
-                        app.filter_input.clear();
-                        app.filter_cursor_pos = 0;
-                        app.apply_filter();
+                        handle_filter_clear(app);
                     }
                     KeyCode::Char(c) => {
                         // Add character to filter input
@@ -277,9 +292,7 @@ pub async fn handle_key_event(
                 AppMode::InstallSelectModelFilter => match key.code {
                     KeyCode::Char('c') if key.modifiers.contains(KeyModifiers::CONTROL) => {
                         // Clear filter input with Ctrl+C
-                        app.registry_filter_input.clear();
-                        app.registry_filter_cursor_pos = 0;
-                        app.apply_registry_filter();
+                        handle_filter_clear(app);
                     }
                     KeyCode::Char(c) => {
                         // Add character to registry filter input

--- a/src/handlers.rs
+++ b/src/handlers.rs
@@ -21,7 +21,7 @@ pub async fn handle_key_event(
 ) -> Result<bool> {
     if key.kind == KeyEventKind::Press || key.kind == KeyEventKind::Repeat {
         let mut handled_globally = false;
-        if app.current_mode != AppMode::RunningOllama && app.current_mode != AppMode::Help && app.current_mode != AppMode::Filter && app.current_mode != AppMode::InstallSelectModelFilter {
+        if app.is_global_key_handling_enabled() {
             match key.code {
                 KeyCode::Char('h') | KeyCode::Char('?') => {
                     app.previous_mode = Some(app.current_mode.clone());

--- a/src/handlers.rs
+++ b/src/handlers.rs
@@ -21,7 +21,7 @@ pub async fn handle_key_event(
 ) -> Result<bool> {
     if key.kind == KeyEventKind::Press || key.kind == KeyEventKind::Repeat {
         let mut handled_globally = false;
-        if app.current_mode != AppMode::RunningOllama && app.current_mode != AppMode::Help && app.current_mode != AppMode::Filter {
+        if app.current_mode != AppMode::RunningOllama && app.current_mode != AppMode::Help && app.current_mode != AppMode::Filter && app.current_mode != AppMode::InstallSelectModelFilter {
             match key.code {
                 KeyCode::Char('h') | KeyCode::Char('?') => {
                     app.previous_mode = Some(app.current_mode.clone());
@@ -87,6 +87,12 @@ pub async fn handle_key_event(
                     _ => {}
                 },
                 AppMode::Filter => match key.code {
+                    KeyCode::Char('c') if key.modifiers.contains(KeyModifiers::CONTROL) => {
+                        // Clear filter input with Ctrl+C
+                        app.filter_input.clear();
+                        app.filter_cursor_pos = 0;
+                        app.apply_filter();
+                    }
                     KeyCode::Char(c) => {
                         // Add character to filter input
                         app.filter_input_char(c);
@@ -116,12 +122,6 @@ pub async fn handle_key_event(
                         app.current_mode = AppMode::Normal;
                         app.status_message = Some("Filter cleared".to_string());
                     }
-                    KeyCode::Char('c') if key.modifiers.contains(KeyModifiers::CONTROL) => {
-                        // Clear filter input with Ctrl+C
-                        app.filter_input.clear();
-                        app.filter_cursor_pos = 0;
-                        app.apply_filter();
-                    }
                     _ => {}
                 },
                 AppMode::ConfirmDelete => match key.code {
@@ -146,8 +146,21 @@ pub async fn handle_key_event(
                     _ => {}
                 },
                 AppMode::InstallSelectModel => match key.code {
+                    KeyCode::Char('/') => {
+                        // Enter registry filter mode
+                        app.current_mode = AppMode::InstallSelectModelFilter;
+                        app.registry_filter_input.clear();
+                        app.registry_filter_cursor_pos = 0;
+                        app.install_error = None;
+                    }
+                    KeyCode::Char('c') if key.modifiers.contains(KeyModifiers::CONTROL) => {
+                        // Clear registry filter with Ctrl+C
+                        if app.is_registry_filtered {
+                            app.clear_registry_filter();
+                        }
+                    }
                     KeyCode::Char('j') | KeyCode::Down => {
-                        let len = app.registry_models.len();
+                        let len = app.get_current_registry_models().len();
                         if len > 0 {
                             let i = match app.registry_model_list_state.selected() {
                                 Some(i) => (i + 1) % len,
@@ -157,7 +170,7 @@ pub async fn handle_key_event(
                         }
                     }
                     KeyCode::Char('k') | KeyCode::Up => {
-                        let len = app.registry_models.len();
+                        let len = app.get_current_registry_models().len();
                         if len > 0 {
                             let i = match app.registry_model_list_state.selected() {
                                 Some(i) => (i + len - 1) % len,
@@ -168,7 +181,7 @@ pub async fn handle_key_event(
                     }
                     KeyCode::Enter => {
                         if let Some(selected_index) = app.registry_model_list_state.selected() {
-                            if let Some(model_name) = app.registry_models.get(selected_index).cloned() {
+                            if let Some(model_name) = app.get_current_registry_models().get(selected_index).cloned() {
                                 app.selected_registry_model = Some(model_name.clone());
                                 app.current_mode = AppMode::InstallSelectTag;
                                 app.is_fetching_registry = true;
@@ -188,6 +201,7 @@ pub async fn handle_key_event(
                         app.current_mode = AppMode::Normal;
                         app.install_error = None;
                         app.is_fetching_registry = false;
+                        app.clear_registry_filter();
                     }
                     _ => {}
                 },
@@ -260,6 +274,44 @@ pub async fn handle_key_event(
                     // Input is ignored while installing.
                 }
                 AppMode::RunningOllama => unreachable!(),
+                AppMode::InstallSelectModelFilter => match key.code {
+                    KeyCode::Char('c') if key.modifiers.contains(KeyModifiers::CONTROL) => {
+                        // Clear filter input with Ctrl+C
+                        app.registry_filter_input.clear();
+                        app.registry_filter_cursor_pos = 0;
+                        app.apply_registry_filter();
+                    }
+                    KeyCode::Char(c) => {
+                        // Add character to registry filter input
+                        app.registry_filter_input_char(c);
+                    }
+                    KeyCode::Backspace => {
+                        // Remove character from registry filter input
+                        app.registry_filter_input_backspace();
+                    }
+                    KeyCode::Left => {
+                        app.registry_filter_cursor_left();
+                    }
+                    KeyCode::Right => {
+                        app.registry_filter_cursor_right();
+                    }
+                    KeyCode::Enter => {
+                        // Confirm filter and return to install select mode
+                        app.current_mode = AppMode::InstallSelectModel;
+                        app.install_error = if app.is_registry_filtered {
+                            Some(format!("Filter: '{}' ({} models)", app.registry_filter_input, app.get_current_registry_models().len()))
+                        } else {
+                            None
+                        };
+                    }
+                    KeyCode::Esc => {
+                        // Cancel filter - clear it and return to install select mode
+                        app.clear_registry_filter();
+                        app.current_mode = AppMode::InstallSelectModel;
+                        app.install_error = Some("Filter cleared".to_string());
+                    }
+                    _ => {}
+                },
                 AppMode::Help => match key.code {
                     KeyCode::Char('h') | KeyCode::Char('?') | KeyCode::Char('q') | KeyCode::Esc => {
                         app.current_mode = app.previous_mode.take().unwrap_or(AppMode::Normal);
@@ -294,7 +346,10 @@ pub fn handle_app_event(event: AppEvent, app: &mut AppState) {
             match result {
                 Ok(models) => {
                     app.registry_models = models;
-                    if !app.registry_models.is_empty() {
+                    // Reapply filter if it was active
+                    if app.is_registry_filtered {
+                        app.apply_registry_filter();
+                    } else if !app.registry_models.is_empty() {
                         app.registry_model_list_state.select(Some(0));
                     } else {
                         app.registry_model_list_state.select(None);

--- a/src/ui.rs
+++ b/src/ui.rs
@@ -10,6 +10,10 @@ use ratatui::{
     Frame,
 };
 
+/// Cursor character for filter input fields
+/// Uses ASCII underline character for maximum terminal compatibility
+const CURSOR_CHAR: char = '_';
+
 fn draw_help_modal(f: &mut Frame) {
     let block = Block::default()
         .title("Help - Shortcuts")
@@ -159,8 +163,8 @@ fn draw_filter_input(f: &mut Frame, app: &AppState, area: Rect) {
     // Create the input display with cursor
     let mut input_display = app.filter_input.clone();
     if app.current_mode == AppMode::Filter {
-        // Insert cursor character at cursor position
-        input_display.insert(app.filter_cursor_pos, '█');
+        // Insert cursor character at cursor position (using ASCII-safe cursor)
+        input_display.insert(app.filter_cursor_pos, CURSOR_CHAR);
     }
 
     let input_paragraph = Paragraph::new(input_display)
@@ -402,8 +406,8 @@ fn draw_registry_filter_input(f: &mut Frame, app: &AppState, area: Rect) {
     // Create the input display with cursor
     let mut input_display = app.registry_filter_input.clone();
     if app.current_mode == AppMode::InstallSelectModelFilter {
-        // Insert cursor character at cursor position
-        input_display.insert(app.registry_filter_cursor_pos, '█');
+        // Insert cursor character at cursor position (using ASCII-safe cursor)
+        input_display.insert(app.registry_filter_cursor_pos, CURSOR_CHAR);
     }
 
     let input_paragraph = Paragraph::new(input_display)

--- a/src/ui.rs
+++ b/src/ui.rs
@@ -164,7 +164,8 @@ fn draw_filter_input(f: &mut Frame, app: &AppState, area: Rect) {
     let mut input_display = app.filter_input.clone();
     if app.current_mode == AppMode::Filter {
         // Insert cursor character at cursor position (using ASCII-safe cursor)
-        input_display.insert(app.filter_cursor_pos, CURSOR_CHAR);
+        let cursor_pos = std::cmp::min(app.filter_cursor_pos, input_display.len());
+        input_display.insert(cursor_pos, CURSOR_CHAR);
     }
 
     let input_paragraph = Paragraph::new(input_display)
@@ -407,7 +408,8 @@ fn draw_registry_filter_input(f: &mut Frame, app: &AppState, area: Rect) {
     let mut input_display = app.registry_filter_input.clone();
     if app.current_mode == AppMode::InstallSelectModelFilter {
         // Insert cursor character at cursor position (using ASCII-safe cursor)
-        input_display.insert(app.registry_filter_cursor_pos, CURSOR_CHAR);
+        let cursor_pos = std::cmp::min(app.registry_filter_cursor_pos, input_display.len());
+        input_display.insert(cursor_pos, CURSOR_CHAR);
     }
 
     let input_paragraph = Paragraph::new(input_display)


### PR DESCRIPTION
  ## Summary

  Extends the existing search and filter functionality (currently available for installed models via /) to the
  installable models list when using the install feature (i key). Users can now search and filter through the Ollama
  registry models during installation, making it much easier to find specific models.

  ## Changes Made

  ### Core Functionality

  - New App Mode: Added InstallSelectModelFilter mode for handling filter input during model installation
  - Registry Filter State: Extended AppState with registry-specific filter fields:
    - filtered_registry_models: Vec<String>
    - registry_filter_input: String
    - is_registry_filtered: bool
    - registry_filter_cursor_pos: usize

  ### Key Features

  - Unified Filter System: Consistent filtering experience between installed and registry models
  - Real-time Search: Filter updates as you type, with immediate visual feedback
  - Filter Persistence: Filter state maintained during registry model browsing
  - Visual Indicators: Shows filtered count in dialog title (filtered: X/Y models)

  ### User Interface

  - Filter Input: Dedicated filter input area with cursor visualization
  - Status Messages: Clear feedback about filter state and results
  - Help Integration: Updated help screen with install mode filter instructions

  ## Usage

  1. Press i to enter install mode
  2. Press / to start filtering registry models
  3. Type to search/filter models in real-time
  4. Use standard navigation:
    - Enter: Confirm filter and return to model selection
    - Esc: Cancel filter and clear it
    - Ctrl+C: Clear current filter input
    - Arrow keys: Navigate cursor in filter input
  5. Navigate filtered results with ↑/↓ or j/k
  6. Select model and proceed with installation as before

  ## Technical Implementation

  ### Files Modified

  - src/app.rs (+89 lines): Registry filter state and methods
  - src/handlers.rs (+70 lines): Key handling for registry filter mode
  - src/ui.rs (+80 lines): UI rendering for registry filter input and updated dialogs

  ### Key Methods Added

  - get_current_registry_models(): Returns filtered or full registry model list
  - apply_registry_filter(): Applies current filter to registry models
  - clear_registry_filter(): Resets registry filter state
  - registry_filter_input_char(): Handles character input for filter
  - registry_filter_input_backspace(): Handles backspace in filter input

  ## Testing

  - ✅ Builds successfully with cargo build --release
  - ✅ All existing functionality preserved
  - ✅ Filter behavior consistent with installed models filter
  - ✅ No breaking changes to existing workflows

  ## Demo

  The filter functionality mirrors the existing installed models filter:
  - Enter filter mode with /
  - Real-time filtering as you type
  - Visual cursor in input field
  - Clear filter state indicators
